### PR TITLE
feat(trivia): add title / difficulty-based filtering in getAllTrivias API

### DIFF
--- a/libs/dto/page.dto.ts
+++ b/libs/dto/page.dto.ts
@@ -3,13 +3,13 @@ import { Type } from 'class-transformer';
 import {
   IsEnum,
   IsOptional,
-  IsString,
   IsInt,
   Min,
   Max,
   IsArray,
   IsNumber,
 } from 'class-validator';
+import { DIFFICULTY_LEVEL } from 'libs/enums/difficulty.enum';
 import { Order } from 'libs/enums/order.enum';
 
 export class PageOptionsDto {
@@ -18,10 +18,12 @@ export class PageOptionsDto {
   @IsOptional()
   readonly order: Order = Order.ASC;
 
-  @ApiPropertyOptional()
-  @IsString()
+  @ApiPropertyOptional({
+    enum: DIFFICULTY_LEVEL,
+  })
+  @IsEnum(DIFFICULTY_LEVEL)
   @IsOptional()
-  readonly orderBy?: string;
+  readonly filterBy?: DIFFICULTY_LEVEL;
 
   @ApiPropertyOptional({
     minimum: 1,

--- a/libs/dto/page.dto.ts
+++ b/libs/dto/page.dto.ts
@@ -8,6 +8,7 @@ import {
   Max,
   IsArray,
   IsNumber,
+  IsString,
 } from 'class-validator';
 import { DIFFICULTY_LEVEL } from 'libs/enums/difficulty.enum';
 import { Order } from 'libs/enums/order.enum';
@@ -24,6 +25,11 @@ export class PageOptionsDto {
   @IsEnum(DIFFICULTY_LEVEL)
   @IsOptional()
   readonly filterBy?: DIFFICULTY_LEVEL;
+
+  @ApiPropertyOptional({})
+  @IsString()
+  @IsOptional()
+  readonly searchTerm?: string;
 
   @ApiPropertyOptional({
     minimum: 1,

--- a/libs/utils/createPageOptionFallBack.ts
+++ b/libs/utils/createPageOptionFallBack.ts
@@ -16,6 +16,7 @@ export const createPageOptionFallBack = (
     page?: number;
     numOfItemsPerPage?: number;
     filterBy?: DIFFICULTY_LEVEL;
+    searchTerm?: string;
   },
 ) => {
   const order = pageOptionsDto.order || defaults?.order || Order.DESC;
@@ -24,6 +25,7 @@ export const createPageOptionFallBack = (
     pageOptionsDto.numOfItemsPerPage || defaults?.numOfItemsPerPage || 10;
   const skip = (page - 1) * numOfItemsPerPage;
   const filterBy = pageOptionsDto.filterBy || defaults?.filterBy;
+  const searchTerm = pageOptionsDto.searchTerm || defaults?.searchTerm;
 
   const pageOptionsDtoFallBack: PageOptionsDto = {
     order,
@@ -31,6 +33,7 @@ export const createPageOptionFallBack = (
     numOfItemsPerPage,
     skip,
     filterBy,
+    searchTerm,
   };
 
   return pageOptionsDtoFallBack;

--- a/libs/utils/createPageOptionFallBack.ts
+++ b/libs/utils/createPageOptionFallBack.ts
@@ -1,4 +1,5 @@
 import { PageOptionsDto } from 'libs/dto/page.dto';
+import { DIFFICULTY_LEVEL } from 'libs/enums/difficulty.enum';
 import { Order } from 'libs/enums/order.enum';
 
 /**
@@ -14,7 +15,7 @@ export const createPageOptionFallBack = (
     order?: Order;
     page?: number;
     numOfItemsPerPage?: number;
-    orderBy?: string;
+    filterBy?: DIFFICULTY_LEVEL;
   },
 ) => {
   const order = pageOptionsDto.order || defaults?.order || Order.DESC;
@@ -22,14 +23,14 @@ export const createPageOptionFallBack = (
   const numOfItemsPerPage =
     pageOptionsDto.numOfItemsPerPage || defaults?.numOfItemsPerPage || 10;
   const skip = (page - 1) * numOfItemsPerPage;
-  const orderBy = pageOptionsDto.orderBy || defaults?.orderBy || 'createdAt';
+  const filterBy = pageOptionsDto.filterBy || defaults?.filterBy;
 
   const pageOptionsDtoFallBack: PageOptionsDto = {
     order,
     page,
     numOfItemsPerPage,
     skip,
-    orderBy,
+    filterBy,
   };
 
   return pageOptionsDtoFallBack;

--- a/modules/trivia/trivia.service.ts
+++ b/modules/trivia/trivia.service.ts
@@ -72,13 +72,19 @@ export class TriviaService {
     options: PageOptionsDto,
   ): Promise<PaginationResponseDto<TriviaResponseDto>> {
     const pageOptionsDtoFallBack = createPageOptionFallBack(options);
-    const { order, skip, numOfItemsPerPage, filterBy } = pageOptionsDtoFallBack;
+    const { order, skip, numOfItemsPerPage, filterBy, searchTerm } =
+      pageOptionsDtoFallBack;
 
     if (order !== Order.ASC && order !== Order.DESC) {
       throw new BadRequestException('Order must be either "asc" or "desc"');
     }
 
     const query: any = {};
+
+    if (searchTerm) {
+      query.title = { $regex: searchTerm, $options: 'i' };
+    }
+
     if (filterBy) {
       query.difficulty = filterBy;
     }

--- a/modules/trivia/trivia.service.ts
+++ b/modules/trivia/trivia.service.ts
@@ -72,20 +72,25 @@ export class TriviaService {
     options: PageOptionsDto,
   ): Promise<PaginationResponseDto<TriviaResponseDto>> {
     const pageOptionsDtoFallBack = createPageOptionFallBack(options);
-    const { order, skip, numOfItemsPerPage } = pageOptionsDtoFallBack;
+    const { order, skip, numOfItemsPerPage, filterBy } = pageOptionsDtoFallBack;
 
     if (order !== Order.ASC && order !== Order.DESC) {
       throw new BadRequestException('Order must be either "asc" or "desc"');
     }
 
+    const query: any = {};
+    if (filterBy) {
+      query.difficulty = filterBy;
+    }
+
     const [allTrivias, itemCount] = await Promise.all([
       this.triviaRepo
-        .find()
+        .find(query)
         .sort({ createdAt: order === Order.ASC ? 1 : -1 })
         .skip(skip)
         .limit(numOfItemsPerPage)
         .exec(),
-      this.triviaRepo.countDocuments().exec(),
+      this.triviaRepo.countDocuments(query).exec(),
     ]);
 
     const triviaResponse = await Promise.all(


### PR DESCRIPTION
- Implemented filtering logic to return trivias based on the provided `filterBy` or `searchTerm` value.
- Updated query to include dynamic filtering by difficulty or title.
- Adjusted item count to reflect filtered results.