### PR TITLE
feat: calculate and store endTimeStamp as Unix timestamp

### DIFF
--- a/libs/dto/trivia.dto.ts
+++ b/libs/dto/trivia.dto.ts
@@ -79,6 +79,9 @@ export class TriviaResponseDto {
   @ApiProperty({ description: 'Duration of the trivia in seconds' })
   duration: string;
 
+  @ApiProperty({ description: 'TimeStamp of when the trivia ends' })
+  endTimeStamp: number;
+
   @ApiProperty({
     description: 'Difficulty level of the trivia',
     enum: DIFFICULTY_LEVEL,

--- a/libs/mapper/trivia.mapper.ts
+++ b/libs/mapper/trivia.mapper.ts
@@ -12,6 +12,7 @@ export const toTriviaResponse = (
     title: trivia.title,
     duration: parseMinutes(computeTriviaMinutes(trivia.duration.toString())),
     createdAt: trivia.createdAt,
+    endTimeStamp: trivia.endTimeStamp,
     difficulty: trivia.difficulty,
     prize: trivia.prize,
     maxWinners: trivia.maxWinners,

--- a/libs/schema/trivia.schema.ts
+++ b/libs/schema/trivia.schema.ts
@@ -61,8 +61,7 @@ export const TriviaSchema = SchemaFactory.createForClass(Trivia);
 TriviaSchema.pre<Trivia>('save', function (next) {
   if (!this.endTimeStamp) {
     this.endTimeStamp = Math.floor(
-      new Date(this.createdAt.getTime() + this.duration * 1000).getTime() /
-        1000,
+      new Date(this.createdAt).valueOf() + this.duration * 1000,
     );
   }
   this.updatedAt = new Date();

--- a/libs/schema/trivia.schema.ts
+++ b/libs/schema/trivia.schema.ts
@@ -1,4 +1,5 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+
 import { Base } from './base.schema';
 import { ApiProperty } from '@nestjs/swagger';
 import { HydratedDocument } from 'mongoose';
@@ -16,6 +17,10 @@ export class Trivia extends Base {
   @ApiProperty({ description: 'Duration of the trivia in seconds' })
   @Prop({ required: true })
   duration: number;
+
+  @ApiProperty({ description: 'Timestamp for when the trivia ends' })
+  @Prop({})
+  endTimeStamp: number;
 
   @ApiProperty({
     description: 'Difficulty level of the trivia',
@@ -52,3 +57,15 @@ export class Trivia extends Base {
 }
 
 export const TriviaSchema = SchemaFactory.createForClass(Trivia);
+
+TriviaSchema.pre<Trivia>('save', function (next) {
+  if (!this.endTimeStamp) {
+    this.endTimeStamp = Math.floor(
+      new Date(this.createdAt.getTime() + this.duration * 1000).getTime() /
+        1000,
+    );
+  }
+  this.updatedAt = new Date();
+
+  next();
+});

--- a/libs/schema/trivia.schema.ts
+++ b/libs/schema/trivia.schema.ts
@@ -60,9 +60,7 @@ export const TriviaSchema = SchemaFactory.createForClass(Trivia);
 
 TriviaSchema.pre<Trivia>('save', function (next) {
   if (!this.endTimeStamp) {
-    this.endTimeStamp = Math.floor(
-      new Date(this.createdAt).valueOf() + this.duration * 1000,
-    );
+    this.endTimeStamp = this.createdAt.getTime() + this.duration * 1000;
   }
   this.updatedAt = new Date();
 


### PR DESCRIPTION
## Description

This PR introduces the following changes:
- Automatically calculates the `endTimeStamp` as a Unix timestamp (in seconds) based on the `createdAt` field and `duration` of the trivia.
- Adds a pre-save hook in the Mongoose schema to handle this calculation before saving the document.
- Ensures that the `updatedAt` field is also updated to the current time on each save.

## Motivation
By using a pre-save hook, we eliminate the need to manually calculate `endTimeStamp` in various parts of the codebase, ensuring consistency and reducing code duplication.
