### PR TITLE
feat(trivia): update endTimeStamp handling and status logic

### DIFF
--- a/libs/dto/page.dto.ts
+++ b/libs/dto/page.dto.ts
@@ -54,14 +54,14 @@ export class PageOptionsDto extends BasePageOptionsDto {
   })
   @IsEnum(DIFFICULTY_LEVEL)
   @IsOptional()
-  readonly filterByDifficulty?: DIFFICULTY_LEVEL;
+  readonly difficulty?: DIFFICULTY_LEVEL;
 
   @ApiPropertyOptional({
     enum: TRIVIA_STATUS,
   })
   @IsEnum(TRIVIA_STATUS)
   @IsOptional()
-  readonly filterByStatus?: TRIVIA_STATUS;
+  readonly status?: TRIVIA_STATUS;
 
   @ApiPropertyOptional({})
   @IsString()

--- a/libs/dto/page.dto.ts
+++ b/libs/dto/page.dto.ts
@@ -12,7 +12,7 @@ import {
 } from 'class-validator';
 import { DIFFICULTY_LEVEL } from 'libs/enums/difficulty.enum';
 import { Order } from 'libs/enums/order.enum';
-import { SUBMISSION_STATUS } from 'libs/enums/status.enum';
+import { SUBMISSION_STATUS, TRIVIA_STATUS } from 'libs/enums/status.enum';
 
 export class BasePageOptionsDto {
   @ApiProperty({ enum: Order, default: Order.ASC })
@@ -54,7 +54,14 @@ export class PageOptionsDto extends BasePageOptionsDto {
   })
   @IsEnum(DIFFICULTY_LEVEL)
   @IsOptional()
-  readonly filterBy?: DIFFICULTY_LEVEL;
+  readonly filterByDifficulty?: DIFFICULTY_LEVEL;
+
+  @ApiPropertyOptional({
+    enum: TRIVIA_STATUS,
+  })
+  @IsEnum(TRIVIA_STATUS)
+  @IsOptional()
+  readonly filterByStatus?: TRIVIA_STATUS;
 
   @ApiPropertyOptional({})
   @IsString()

--- a/libs/schema/trivia.schema.ts
+++ b/libs/schema/trivia.schema.ts
@@ -66,3 +66,18 @@ TriviaSchema.pre<Trivia>('save', function (next) {
 
   next();
 });
+
+TriviaSchema.pre('findOneAndUpdate', function (next) {
+  const update = this.getUpdate() as Partial<Trivia>;
+
+  if (update.duration && !update.endTimeStamp) {
+    const durationInMs = update.duration * 1000;
+
+    const now = new Date().getTime();
+    update.endTimeStamp = now + durationInMs;
+  }
+
+  update.updatedAt = new Date();
+  this.setUpdate(update);
+  next();
+});

--- a/libs/utils/createPageOptionFallBack.ts
+++ b/libs/utils/createPageOptionFallBack.ts
@@ -1,6 +1,7 @@
 import { PageOptionsDto } from 'libs/dto/page.dto';
 import { DIFFICULTY_LEVEL } from 'libs/enums/difficulty.enum';
 import { Order } from 'libs/enums/order.enum';
+import { TRIVIA_STATUS } from 'libs/enums/status.enum';
 
 /**
  * @description This function accepts a pagination query object and
@@ -15,7 +16,8 @@ export const createPageOptionFallBack = (
     order?: Order;
     page?: number;
     numOfItemsPerPage?: number;
-    filterBy?: DIFFICULTY_LEVEL;
+    filterByDifficulty?: DIFFICULTY_LEVEL;
+    filterByStatus?: TRIVIA_STATUS;
     searchTerm?: string;
   },
 ) => {
@@ -24,7 +26,10 @@ export const createPageOptionFallBack = (
   const numOfItemsPerPage =
     pageOptionsDto.numOfItemsPerPage || defaults?.numOfItemsPerPage || 10;
   const skip = (page - 1) * numOfItemsPerPage;
-  const filterBy = pageOptionsDto.filterBy || defaults?.filterBy;
+  const filterByDifficulty =
+    pageOptionsDto.filterByDifficulty || defaults?.filterByDifficulty;
+  const filterByStatus =
+    pageOptionsDto.filterByStatus || defaults?.filterByStatus;
   const searchTerm = pageOptionsDto.searchTerm || defaults?.searchTerm;
 
   const pageOptionsDtoFallBack: PageOptionsDto = {
@@ -32,7 +37,8 @@ export const createPageOptionFallBack = (
     page,
     numOfItemsPerPage,
     skip,
-    filterBy,
+    filterByDifficulty,
+    filterByStatus,
     searchTerm,
   };
 

--- a/libs/utils/createPageOptionFallBack.ts
+++ b/libs/utils/createPageOptionFallBack.ts
@@ -16,8 +16,8 @@ export const createPageOptionFallBack = (
     order?: Order;
     page?: number;
     numOfItemsPerPage?: number;
-    filterByDifficulty?: DIFFICULTY_LEVEL;
-    filterByStatus?: TRIVIA_STATUS;
+    difficulty?: DIFFICULTY_LEVEL;
+    status?: TRIVIA_STATUS;
     searchTerm?: string;
   },
 ) => {
@@ -26,10 +26,8 @@ export const createPageOptionFallBack = (
   const numOfItemsPerPage =
     pageOptionsDto.numOfItemsPerPage || defaults?.numOfItemsPerPage || 10;
   const skip = (page - 1) * numOfItemsPerPage;
-  const filterByDifficulty =
-    pageOptionsDto.filterByDifficulty || defaults?.filterByDifficulty;
-  const filterByStatus =
-    pageOptionsDto.filterByStatus || defaults?.filterByStatus;
+  const filterByDifficulty = pageOptionsDto.difficulty || defaults?.difficulty;
+  const filterByStatus = pageOptionsDto.status || defaults?.status;
   const searchTerm = pageOptionsDto.searchTerm || defaults?.searchTerm;
 
   const pageOptionsDtoFallBack: PageOptionsDto = {
@@ -37,8 +35,8 @@ export const createPageOptionFallBack = (
     page,
     numOfItemsPerPage,
     skip,
-    filterByDifficulty,
-    filterByStatus,
+    difficulty: filterByDifficulty,
+    status: filterByStatus,
     searchTerm,
   };
 

--- a/modules/trivia/trivia.service.ts
+++ b/modules/trivia/trivia.service.ts
@@ -78,8 +78,14 @@ export class TriviaService {
     options: PageOptionsDto,
   ): Promise<PaginationResponseDto<TriviaResponseDto>> {
     const pageOptionsDtoFallBack = createPageOptionFallBack(options);
-    const { order, skip, numOfItemsPerPage, filterBy, searchTerm } =
-      pageOptionsDtoFallBack;
+    const {
+      order,
+      skip,
+      numOfItemsPerPage,
+      filterByDifficulty: difficulty,
+      filterByStatus: status,
+      searchTerm,
+    } = pageOptionsDtoFallBack;
 
     if (order !== Order.ASC && order !== Order.DESC) {
       throw new BadRequestException('Order must be either "asc" or "desc"');
@@ -91,8 +97,12 @@ export class TriviaService {
       query.title = { $regex: searchTerm, $options: 'i' };
     }
 
-    if (filterBy) {
-      query.difficulty = filterBy;
+    if (difficulty) {
+      query.difficulty = difficulty;
+    }
+
+    if (status) {
+      query.status = status;
     }
 
     const [allTrivias, itemCount] = await Promise.all([
@@ -107,7 +117,7 @@ export class TriviaService {
 
     const triviaResponse = await Promise.all(
       allTrivias.map(async (trivia) => {
-        if (this.hasTimeElapsed(trivia.createdAt, trivia.duration)) {
+        if (this.hasTimeElapsed(trivia.endTimeStamp)) {
           await this.triviaRepo
             .findByIdAndUpdate(trivia._id, { status: 'expired' }, { new: true })
             .exec();
@@ -141,12 +151,33 @@ export class TriviaService {
   }
 
   async updateTrivia(id: string, triviaDto: UpdateTriviaDto) {
+    const existingTrivia = await this.triviaRepo.findById(id).exec();
+
+    if (!existingTrivia) {
+      throw new NotFoundException('Trivia not found.');
+    }
+
+    let newEndTimeStamp = existingTrivia.endTimeStamp;
+
+    if (triviaDto.duration) {
+      newEndTimeStamp = Date.now() + triviaDto.duration * 1000;
+    }
+
+    let newStatus = existingTrivia.status;
+    if (
+      newEndTimeStamp > Date.now() &&
+      existingTrivia.status === TRIVIA_STATUS.EXPIRED
+    ) {
+      newStatus = TRIVIA_STATUS.ONGOING;
+    }
+
     const updatedTrivia = await this.triviaRepo
       .findOneAndUpdate(
         { _id: id },
         {
           ...triviaDto,
           updatedAt: new Date(),
+          status: newStatus,
         },
         { new: true },
       )
@@ -190,7 +221,7 @@ export class TriviaService {
       throw new NotFoundException(ERROR.TRIVIA_NOT_FOUND);
     }
 
-    if (this.hasTimeElapsed(trivia.createdAt, trivia.duration)) {
+    if (this.hasTimeElapsed(trivia.endTimeStamp)) {
       throw new ConflictException(ERROR.TRIVIA_EXPIRED);
     }
 
@@ -401,11 +432,16 @@ export class TriviaService {
     return leaderboard;
   }
 
-  private hasTimeElapsed(createdAt: Date, duration: number): boolean {
-    const currentTime = new Date();
-    const expirationTime = new Date(createdAt.getTime() + duration * 1000);
+  // private hasTimeElapsed(createdAt: Date, duration: number): boolean {
+  //   const currentTime = new Date();
+  //   const expirationTime = new Date(createdAt.getTime() + duration * 1000);
 
-    return currentTime >= expirationTime;
+  //   return currentTime >= expirationTime;
+  // }
+
+  private hasTimeElapsed(endTimeStamp: number): boolean {
+    const currentTime = Date.now();
+    return currentTime >= endTimeStamp;
   }
 
   async getUserSubmissions(userId: string): Promise<SubmissionResponseDto[]> {

--- a/modules/trivia/trivia.service.ts
+++ b/modules/trivia/trivia.service.ts
@@ -78,14 +78,8 @@ export class TriviaService {
     options: PageOptionsDto,
   ): Promise<PaginationResponseDto<TriviaResponseDto>> {
     const pageOptionsDtoFallBack = createPageOptionFallBack(options);
-    const {
-      order,
-      skip,
-      numOfItemsPerPage,
-      filterByDifficulty: difficulty,
-      filterByStatus: status,
-      searchTerm,
-    } = pageOptionsDtoFallBack;
+    const { order, skip, numOfItemsPerPage, difficulty, status, searchTerm } =
+      pageOptionsDtoFallBack;
 
     if (order !== Order.ASC && order !== Order.DESC) {
       throw new BadRequestException('Order must be either "asc" or "desc"');

--- a/modules/user/user.service.ts
+++ b/modules/user/user.service.ts
@@ -7,7 +7,7 @@ import {
 } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { CreateUserDto, UpdateUserDto } from 'libs/dto';
-import { PageMetaDto, PageOptionsDto } from 'libs/dto/page.dto';
+import { BasePageOptionsDto, PageMetaDto } from 'libs/dto/page.dto';
 import { UploadImageDto } from 'libs/dto/upload-image.dto';
 import { Order } from 'libs/enums/order.enum';
 import { toUserResponse } from 'libs/mapper/user.mapper';
@@ -55,7 +55,7 @@ export class UserService {
     return null;
   }
 
-  async getAllUsers(options: PageOptionsDto) {
+  async getAllUsers(options: BasePageOptionsDto) {
     const pageOptionsDtoFallBack = createPageOptionFallBack(options);
     const { order, skip, numOfItemsPerPage } = pageOptionsDtoFallBack;
 


### PR DESCRIPTION
## Summary
This PR introduces improvements to the Trivia update logic and time-elapsed check:

1. **New EndTimeStamp Calculation**:
   - Updates `endTimeStamp` using the current time (`Date.now()`) when the trivia duration is extended.

2. **Status Adjustment**:
   - Automatically changes the status of expired challenges to `ONGOING` if the duration is updated to extend their expiration time into the future.

3. **Simplified Time-Elapsed Check**:
   - Refactored the `hasTimeElapsed` function to directly use `endTimeStamp` instead of recalculating from `createdAt` and `duration`.

## Changes
- Updated `updateTrivia` method to:
  - Recalculate `endTimeStamp` based on the current timestamp.
  - Adjust the status of challenges based on the new expiration time.
- Simplified `hasTimeElapsed` utility to use `endTimeStamp`.
- Ensured timestamps (`updatedAt`) are consistent with current time during updates.

## Testing
- Verified that:
  - Trivia status transitions from `EXPIRED` to `ONGOING` when extended to a future time.
  - `hasTimeElapsed` function correctly determines expiration based on `endTimeStamp`.
- Added manual tests for different scenarios:
  - Extending expired trivia.
  - Keeping ongoing trivia unchanged.
  - Expired trivia remaining expired when not extended.

## Notes
These changes improve the flexibility and accuracy of trivia management, especially in scenarios involving updates to challenges' duration or end times.
