### PR TITLE
fix: update approveSubmission, and disburseAlgos to use PATCH and skip maxWinners check for rejected reviews

### DIFF
--- a/apps/main/src/controllers/trivia.controller.ts
+++ b/apps/main/src/controllers/trivia.controller.ts
@@ -141,12 +141,12 @@ export class TriviaController {
   @ApiOperation({ summary: 'Approve submission' })
   @ApiResponse({ status: 200, description: 'Submission approved.' })
   @UseGuards(AdminJwtAuthGuard)
-  @Patch('approve/:submissionId')
+  @Patch('review-submission/:submissionId')
   async approveSubmission(
     @Param('submissionId') submissionId: string,
     @Query() review: ReviewStatusDto,
   ) {
-    return this.triviaService.approveAnswer(submissionId, review.status);
+    return this.triviaService.reviewSubmission(submissionId, review.status);
   }
 
   @ApiBearerAuth('Bearer')

--- a/apps/main/src/controllers/trivia.controller.ts
+++ b/apps/main/src/controllers/trivia.controller.ts
@@ -141,7 +141,7 @@ export class TriviaController {
   @ApiOperation({ summary: 'Approve submission' })
   @ApiResponse({ status: 200, description: 'Submission approved.' })
   @UseGuards(AdminJwtAuthGuard)
-  @Get('approve/:submissionId')
+  @Patch('approve/:submissionId')
   async approveSubmission(
     @Param('submissionId') submissionId: string,
     @Query() review: ReviewStatusDto,
@@ -158,7 +158,7 @@ export class TriviaController {
     description: "Submission isn't eligible for disbursement.",
   })
   @UseGuards(AdminJwtAuthGuard)
-  @Get(':submissionId/disburse')
+  @Patch(':submissionId/disburse')
   async disburseAlgos(
     @Param('submissionId') submissionId: string,
     @Query() status: DisbursementStatusDto,

--- a/modules/trivia/trivia.service.ts
+++ b/modules/trivia/trivia.service.ts
@@ -289,7 +289,7 @@ export class TriviaService {
     };
   }
 
-  async approveAnswer(submissionId: string, review: REVIEW_STATUS) {
+  async reviewSubmission(submissionId: string, review: REVIEW_STATUS) {
     const submission = await this.submissionRepo.findById(submissionId).exec();
 
     if (!submission) {

--- a/modules/trivia/trivia.service.ts
+++ b/modules/trivia/trivia.service.ts
@@ -307,10 +307,20 @@ export class TriviaService {
       );
     }
 
-    const trivia = await this.triviaRepo.findById(submission.triviaId).exec();
+    if (review === REVIEW_STATUS.APPROVED) {
+      const trivia = await this.triviaRepo.findById(submission.triviaId).exec();
 
-    if (trivia.winners === trivia.maxWinners) {
-      throw new ConflictException(`All winners have already been awarded`);
+      if (trivia.winners === trivia.maxWinners) {
+        throw new ConflictException(`All winners have already been awarded`);
+      }
+
+      await this.triviaRepo
+        .findOneAndUpdate(
+          { _id: trivia._id },
+          { $inc: { winners: 1 } },
+          { new: true },
+        )
+        .exec();
     }
 
     const updatedSubmission = await this.submissionRepo
@@ -331,16 +341,6 @@ export class TriviaService {
         },
       )
       .exec();
-
-    if (review === REVIEW_STATUS.APPROVED) {
-      await this.triviaRepo
-        .findOneAndUpdate(
-          { _id: trivia._id },
-          { $inc: { winners: 1 } },
-          { new: true },
-        )
-        .exec();
-    }
 
     return {
       message: 'Submission has been reviewed successfully',

--- a/modules/user/user.service.ts
+++ b/modules/user/user.service.ts
@@ -66,7 +66,7 @@ export class UserService {
     const [allUsers, itemCount] = await Promise.all([
       this.userRepo
         .find()
-        .sort({ awardedAlgos: order === Order.ASC ? 1 : -1 })
+        .sort({ awardedAlgos: order === Order.ASC ? 1 : -1, _id: 1 })
         .skip(skip)
         .limit(numOfItemsPerPage)
         .exec(),
@@ -80,6 +80,7 @@ export class UserService {
       pageOptionsDto: pageOptionsDtoFallBack,
     });
 
+    // Return paginated response
     return {
       data: userResponse,
       pagination: pageMetaDto,


### PR DESCRIPTION
# Fix Approve Submission Endpoint

## Changes
- Updated `approveSubmission` endpoint to use `PATCH` instead of `GET` for better RESTful compliance.
- Updated `disburseAlgos ` endpoint to use `PATCH` instead of `GET` for better RESTful compliance.
- Modified `approveAnswer` service method to skip `maxWinners` check when the review status is `REJECTED`.
- Improved handling of submission status updates and winners count logic.

## Testing
- Verified the endpoint works correctly with both `APPROVED` and `REJECTED` statuses.
- Confirmed `maxWinners` check is bypassed for rejected reviews.
